### PR TITLE
Add navigation to login and admin screens

### DIFF
--- a/src/components/ArticleHeader.tsx
+++ b/src/components/ArticleHeader.tsx
@@ -1,6 +1,21 @@
+"use client";
+
 import Link from 'next/link'
+import { useSession } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
 
 export default function ArticleHeader() {
+  const { data: session } = useSession()
+  const router = useRouter()
+
+  const handleAvatarClick = () => {
+    if (session) {
+      router.push('/admin')
+    } else {
+      router.push('/auth/signin')
+    }
+  }
+
   return (
     <header className="bg-white shadow-md fixed top-0 left-0 right-0 z-50">
       <div className="container mx-auto px-6 py-3 flex justify-between items-center">
@@ -14,6 +29,14 @@ export default function ArticleHeader() {
           >
             記事作成
           </Link>
+          {!session && (
+            <Link 
+              href="/auth/signin" 
+              className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-md mr-4 transition duration-150 ease-in-out"
+            >
+              ログイン
+            </Link>
+          )}
           <button className="text-gray-600 hover:text-purple-600 focus:outline-none mx-2">
             <span className="material-icons">search</span>
           </button>
@@ -21,8 +44,12 @@ export default function ArticleHeader() {
             <span className="material-icons">notifications</span>
           </button>
           <div className="relative">
-            <button className="focus:outline-none">
-              <div className="w-10 h-10 rounded-full bg-purple-600 flex items-center justify-center text-white text-xl">
+            <button 
+              className="focus:outline-none" 
+              onClick={handleAvatarClick}
+              title={session ? "管理画面へ" : "ログインへ"}
+            >
+              <div className="w-10 h-10 rounded-full bg-purple-600 flex items-center justify-center text-white text-xl hover:bg-purple-700 transition duration-150 ease-in-out">
                 <span className="material-icons">person</span>
               </div>
             </button>


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add login button and avatar navigation to `ArticleHeader.tsx` to provide clear access to login and admin pages.

---

[Open in Web](https://www.cursor.com/agents?id=bc-45f7a7d3-3d66-431b-8676-a563096681da) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-45f7a7d3-3d66-431b-8676-a563096681da)