### PR TITLE
Create articles list page with tailwind css

### DIFF
--- a/src/app/articles/page.tsx
+++ b/src/app/articles/page.tsx
@@ -1,20 +1,105 @@
 'use client';
 
 import { useState, useMemo } from 'react';
-import ArticleListHeaderNew from '@/components/ArticleListHeaderNew';
-import SearchFiltersNew from '@/components/SearchFiltersNew';
-import ArticleGridNew from '@/components/ArticleGridNew';
-import PaginationNew from '@/components/PaginationNew';
+import ArticleHeader from '@/components/ArticleHeader';
+import SearchFilters from '@/components/SearchFilters';
+import ArticleGrid from '@/components/ArticleGrid';
+import Pagination from '@/components/Pagination';
 
 // Sample articles data - in a real app, this would come from an API
-
+const sampleArticles = [
+  {
+    id: '1',
+    title: 'Next.js 14の新機能について',
+    description: 'Next.js 14で追加された新機能と改善点について詳しく解説します。App Routerの進化やパフォーマンス向上について説明します。',
+    tags: ['next', 'react']
+  },
+  {
+    id: '2',
+    title: 'React Hooks完全ガイド',
+    description: 'React Hooksの基本から応用まで、実践的な使い方を学びます。useState、useEffect、カスタムフックの作成方法を解説します。',
+    tags: ['react']
+  },
+  {
+    id: '3',
+    title: 'TypeScript型安全性のベストプラクティス',
+    description: 'TypeScriptを使った型安全なコード作成のベストプラクティスを紹介します。ジェネリクスやユニオン型の活用法も説明します。',
+    tags: ['typescript']
+  },
+  {
+    id: '4',
+    title: 'Tailwind CSSでモダンなUIを作る',
+    description: 'Tailwind CSSを使って効率的にモダンなUIコンポーネントを作成する方法を学びます。レスポンシブデザインの実装も含みます。',
+    tags: ['css', 'tailwind']
+  },
+  {
+    id: '5',
+    title: 'GraphQLとREST APIの比較',
+    description: 'GraphQLとREST APIの違いとそれぞれの適用場面について解説します。実際のプロジェクトでの選択基準も説明します。',
+    tags: ['graphql', 'api']
+  },
+  {
+    id: '6',
+    title: 'Dockerを使った開発環境構築',
+    description: 'Dockerを使って効率的な開発環境を構築する方法を解説します。docker-composeを使った複数サービスの管理も含みます。',
+    tags: ['docker', 'devops']
+  }
+];
 
 export default function ArticlesPage() {
-  
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedTags, setSelectedTags] = useState<string[]>(['next', 'react']);
+  const [currentPage, setCurrentPage] = useState(1);
+  const articlesPerPage = 6;
+
+  // フィルタリングされた記事
+  const filteredArticles = useMemo(() => {
+    return sampleArticles.filter(article => {
+      const matchesSearch = searchQuery === '' || 
+        article.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        article.description.toLowerCase().includes(searchQuery.toLowerCase());
+      
+      const matchesTags = selectedTags.length === 0 || 
+        selectedTags.some(tag => article.tags.includes(tag));
+      
+      return matchesSearch && matchesTags;
+    });
+  }, [searchQuery, selectedTags]);
+
+  // ページネーション
+  const totalPages = Math.ceil(filteredArticles.length / articlesPerPage);
+  const startIndex = (currentPage - 1) * articlesPerPage;
+  const paginatedArticles = filteredArticles.slice(startIndex, startIndex + articlesPerPage);
+
+  const handleSearchChange = (query: string) => {
+    setSearchQuery(query);
+    setCurrentPage(1); // 検索時はページを1に戻す
+  };
+
+  const handleTagsChange = (tags: string[]) => {
+    setSelectedTags(tags);
+    setCurrentPage(1); // フィルター変更時はページを1に戻す
+  };
+
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page);
+  };
 
   return (
     <div className="min-h-screen bg-gray-50">
-     
+      <div className="container mx-auto px-4 py-8">
+        <ArticleHeader />
+        <SearchFilters 
+          onSearchChange={handleSearchChange}
+          onTagsChange={handleTagsChange}
+        />
+        <ArticleGrid articles={paginatedArticles} />
+        <Pagination 
+          currentPage={currentPage}
+          totalPages={totalPages}
+          onPageChange={handlePageChange}
+        />
+      </div>
     </div>
   );
 }

--- a/src/components/ArticleCard.tsx
+++ b/src/components/ArticleCard.tsx
@@ -1,0 +1,21 @@
+interface ArticleCardProps {
+  title: string;
+  description: string;
+  icon?: React.ReactNode;
+}
+
+export default function ArticleCard({ title, description, icon }: ArticleCardProps) {
+  return (
+    <div className="bg-white rounded-lg shadow-md overflow-hidden hover:shadow-xl transition-shadow duration-300">
+      <div className="bg-gray-200 h-48 flex items-center justify-center">
+        <div className="w-24 h-24 bg-blue-400 rounded-full flex items-center justify-center">
+          {icon || <span className="text-white text-sm">アイコン</span>}
+        </div>
+      </div>
+      <div className="p-6">
+        <h2 className="text-xl font-semibold text-gray-800 mb-2">{title}</h2>
+        <p className="text-gray-600 text-sm">{description}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ArticleGrid.tsx
+++ b/src/components/ArticleGrid.tsx
@@ -1,0 +1,27 @@
+import ArticleCard from './ArticleCard';
+
+interface Article {
+  id: string;
+  title: string;
+  description: string;
+  icon?: React.ReactNode;
+}
+
+interface ArticleGridProps {
+  articles: Article[];
+}
+
+export default function ArticleGrid({ articles }: ArticleGridProps) {
+  return (
+    <main className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8 mb-10">
+      {articles.map((article) => (
+        <ArticleCard
+          key={article.id}
+          title={article.title}
+          description={article.description}
+          icon={article.icon}
+        />
+      ))}
+    </main>
+  );
+}

--- a/src/components/ArticleHeader.tsx
+++ b/src/components/ArticleHeader.tsx
@@ -1,0 +1,16 @@
+export default function ArticleHeader() {
+  return (
+    <header className="flex justify-between items-center mb-10">
+      <h1 className="text-3xl font-bold text-purple-700">技術記事</h1>
+      <div className="w-12 h-12 bg-purple-600 rounded-full flex items-center justify-center">
+        <svg 
+          className="w-6 h-6 text-white" 
+          fill="currentColor" 
+          viewBox="0 0 24 24"
+        >
+          <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"/>
+        </svg>
+      </div>
+    </header>
+  );
+}

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+interface PaginationProps {
+  currentPage: number;
+  totalPages: number;
+  onPageChange?: (page: number) => void;
+}
+
+export default function Pagination({ currentPage, totalPages, onPageChange }: PaginationProps) {
+  const handlePageChange = (page: number) => {
+    if (page >= 1 && page <= totalPages) {
+      onPageChange?.(page);
+    }
+  };
+
+  const getVisiblePages = () => {
+    const pages = [];
+    
+    if (totalPages <= 7) {
+      // 7ページ以下の場合は全て表示
+      for (let i = 1; i <= totalPages; i++) {
+        pages.push(i);
+      }
+    } else {
+      // 現在のページ周辺を表示
+      if (currentPage <= 3) {
+        pages.push(1, 2, 3, '...', totalPages - 1, totalPages);
+      } else if (currentPage >= totalPages - 2) {
+        pages.push(1, 2, '...', totalPages - 2, totalPages - 1, totalPages);
+      } else {
+        pages.push(1, '...', currentPage - 1, currentPage, currentPage + 1, '...', totalPages);
+      }
+    }
+    
+    return pages;
+  };
+
+  const visiblePages = getVisiblePages();
+
+  return (
+    <nav className="flex justify-center items-center space-x-2">
+      {/* Previous ボタン */}
+      <button
+        onClick={() => handlePageChange(currentPage - 1)}
+        disabled={currentPage === 1}
+        className={`flex items-center px-3 py-2 rounded-md ${
+          currentPage === 1 
+            ? 'text-gray-400 cursor-not-allowed' 
+            : 'text-gray-600 hover:text-purple-600'
+        }`}
+      >
+        <svg className="w-4 h-4 mr-1" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"/>
+        </svg>
+        Previous
+      </button>
+
+      {/* ページ番号 */}
+      {visiblePages.map((page, index) => (
+        <span key={index}>
+          {typeof page === 'number' ? (
+            <button
+              onClick={() => handlePageChange(page)}
+              className={`px-4 py-2 font-semibold rounded-md ${
+                page === currentPage
+                  ? 'bg-purple-600 text-white'
+                  : 'text-gray-600 hover:bg-gray-200 hover:text-purple-600'
+              }`}
+            >
+              {page}
+            </button>
+          ) : (
+            <span className="text-gray-600">{page}</span>
+          )}
+        </span>
+      ))}
+
+      {/* Next ボタン */}
+      <button
+        onClick={() => handlePageChange(currentPage + 1)}
+        disabled={currentPage === totalPages}
+        className={`flex items-center px-3 py-2 rounded-md ${
+          currentPage === totalPages 
+            ? 'text-gray-400 cursor-not-allowed' 
+            : 'text-gray-600 hover:text-purple-600'
+        }`}
+      >
+        Next
+        <svg className="w-4 h-4 ml-1" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/>
+        </svg>
+      </button>
+    </nav>
+  );
+}

--- a/src/components/SearchFilters.tsx
+++ b/src/components/SearchFilters.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { useState } from 'react';
+
+interface Tag {
+  id: string;
+  name: string;
+  color: string;
+}
+
+interface SearchFiltersProps {
+  onSearchChange?: (query: string) => void;
+  onTagsChange?: (tags: string[]) => void;
+}
+
+export default function SearchFilters({ onSearchChange, onTagsChange }: SearchFiltersProps) {
+  const [selectedTags, setSelectedTags] = useState<Tag[]>([
+    { id: 'next', name: 'Next', color: 'bg-blue-500' },
+    { id: 'react', name: 'React', color: 'bg-teal-500' }
+  ]);
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const removeTag = (tagId: string) => {
+    const updatedTags = selectedTags.filter(tag => tag.id !== tagId);
+    setSelectedTags(updatedTags);
+    onTagsChange?.(updatedTags.map(tag => tag.id));
+  };
+
+  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setSearchQuery(value);
+    onSearchChange?.(value);
+  };
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-10">
+      {/* タグフィルター */}
+      <div className="relative bg-white p-3 rounded-lg shadow-sm border border-gray-200 flex items-center">
+        <div className="flex items-center flex-wrap gap-2 mr-3">
+          {selectedTags.map((tag) => (
+            <span 
+              key={tag.id}
+              className={`${tag.color} text-white px-3 py-1 rounded-full text-sm font-medium flex items-center`}
+            >
+              {tag.name}
+              <button
+                onClick={() => removeTag(tag.id)}
+                className="ml-1 hover:bg-black hover:bg-opacity-20 rounded-full p-0.5"
+              >
+                <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 24 24">
+                  <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
+                </svg>
+              </button>
+            </span>
+          ))}
+        </div>
+        <input 
+          className="flex-grow bg-gray-100 rounded-md p-2 focus:outline-none focus:ring-2 focus:ring-purple-500" 
+          placeholder="" 
+          type="text"
+          value={searchQuery}
+          onChange={handleSearchChange}
+        />
+        <svg className="absolute right-5 w-5 h-5 text-gray-400" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/>
+        </svg>
+      </div>
+
+      {/* 検索入力欄 */}
+      <div className="relative bg-white p-3 rounded-lg shadow-sm border border-gray-200 flex items-center">
+        <input 
+          className="flex-grow bg-gray-100 rounded-md p-2 focus:outline-none focus:ring-2 focus:ring-purple-500" 
+          placeholder="Hinted search text" 
+          type="text"
+        />
+        <svg className="absolute right-5 w-5 h-5 text-gray-400" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/>
+        </svg>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Add `ArticlesPage` and its sub-components to implement the article list screen, replicating the `docs/design/all_view.html` design with Tailwind CSS.

---
<a href="https://cursor.com/background-agent?bcId=bc-fa30053f-3229-407e-84b8-a1021a0ebae4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fa30053f-3229-407e-84b8-a1021a0ebae4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

