### PR TITLE
Create articles list page with tailwind css

### DIFF
--- a/src/app/articles/components/ArticleCard.tsx
+++ b/src/app/articles/components/ArticleCard.tsx
@@ -1,0 +1,30 @@
+interface Article {
+  id: string;
+  title: string;
+  description: string;
+  icon?: string;
+}
+
+interface ArticleCardProps {
+  article: Article;
+  onClick?: () => void;
+}
+
+export default function ArticleCard({ article, onClick }: ArticleCardProps) {
+  return (
+    <div 
+      className="bg-white rounded-lg shadow-md overflow-hidden hover:shadow-xl transition-shadow duration-300 cursor-pointer"
+      onClick={onClick}
+    >
+      <div className="bg-gray-200 h-48 flex items-center justify-center">
+        <div className="w-24 h-24 bg-blue-400 rounded-full flex items-center justify-center">
+          <span className="text-white text-sm">アイコン</span>
+        </div>
+      </div>
+      <div className="p-6">
+        <h2 className="text-xl font-semibold text-gray-800 mb-2">{article.title}</h2>
+        <p className="text-gray-600 text-sm">{article.description}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/articles/components/Header.tsx
+++ b/src/app/articles/components/Header.tsx
@@ -1,0 +1,10 @@
+export default function Header() {
+  return (
+    <header className="flex justify-between items-center mb-10">
+      <h1 className="text-3xl font-bold text-purple-700">技術記事</h1>
+      <div className="w-12 h-12 bg-purple-600 rounded-full flex items-center justify-center">
+        <span className="material-icons text-white text-3xl">person</span>
+      </div>
+    </header>
+  );
+}

--- a/src/app/articles/components/Pagination.tsx
+++ b/src/app/articles/components/Pagination.tsx
@@ -1,0 +1,74 @@
+interface PaginationProps {
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+}
+
+export default function Pagination({ currentPage, totalPages, onPageChange }: PaginationProps) {
+  const renderPageNumbers = () => {
+    const pages = [];
+    const maxVisiblePages = 5;
+    
+    if (totalPages <= maxVisiblePages) {
+      // 全ページを表示
+      for (let i = 1; i <= totalPages; i++) {
+        pages.push(i);
+      }
+    } else {
+      // ページ数が多い場合の省略表示
+      if (currentPage <= 3) {
+        pages.push(1, 2, 3, '...', totalPages - 1, totalPages);
+      } else if (currentPage >= totalPages - 2) {
+        pages.push(1, 2, '...', totalPages - 2, totalPages - 1, totalPages);
+      } else {
+        pages.push(1, '...', currentPage - 1, currentPage, currentPage + 1, '...', totalPages);
+      }
+    }
+    
+    return pages;
+  };
+
+  return (
+    <nav className="flex justify-center items-center space-x-2">
+      {/* Previous ボタン */}
+      <button
+        className="flex items-center px-3 py-2 text-gray-600 hover:text-purple-600 rounded-md disabled:opacity-50 disabled:cursor-not-allowed"
+        onClick={() => onPageChange(currentPage - 1)}
+        disabled={currentPage === 1}
+      >
+        <span className="material-icons text-lg mr-1">arrow_back_ios</span>
+        Previous
+      </button>
+
+      {/* ページ番号 */}
+      {renderPageNumbers().map((page, index) => (
+        <div key={index}>
+          {page === '...' ? (
+            <span className="text-gray-600">...</span>
+          ) : (
+            <button
+              className={`px-4 py-2 rounded-md font-semibold ${
+                currentPage === page
+                  ? 'bg-purple-600 text-white'
+                  : 'text-gray-600 hover:bg-gray-200 hover:text-purple-600'
+              }`}
+              onClick={() => onPageChange(page as number)}
+            >
+              {page}
+            </button>
+          )}
+        </div>
+      ))}
+
+      {/* Next ボタン */}
+      <button
+        className="flex items-center px-3 py-2 text-gray-600 hover:text-purple-600 rounded-md disabled:opacity-50 disabled:cursor-not-allowed"
+        onClick={() => onPageChange(currentPage + 1)}
+        disabled={currentPage === totalPages}
+      >
+        Next
+        <span className="material-icons text-lg ml-1">arrow_forward_ios</span>
+      </button>
+    </nav>
+  );
+}

--- a/src/app/articles/components/SearchAndFilter.tsx
+++ b/src/app/articles/components/SearchAndFilter.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useState } from 'react';
+
+interface Tag {
+  id: string;
+  name: string;
+  color: string;
+}
+
+interface SearchAndFilterProps {
+  selectedTags: Tag[];
+  onTagRemove: (tagId: string) => void;
+  searchValue: string;
+  onSearchChange: (value: string) => void;
+  placeholder?: string;
+}
+
+export default function SearchAndFilter({
+  selectedTags,
+  onTagRemove,
+  searchValue,
+  onSearchChange,
+  placeholder = "Hinted search text"
+}: SearchAndFilterProps) {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-10">
+      {/* タグフィルター付き検索ボックス */}
+      <div className="relative bg-white p-3 rounded-lg shadow-sm border border-gray-200 flex items-center">
+        <div className="flex items-center flex-wrap gap-2 mr-3">
+          {selectedTags.map((tag) => (
+            <span 
+              key={tag.id}
+              className={`${tag.color} text-white px-3 py-1 rounded-full text-sm font-medium flex items-center`}
+            >
+              {tag.name}
+              <span 
+                className="material-icons text-xs ml-1 cursor-pointer"
+                onClick={() => onTagRemove(tag.id)}
+              >
+                close
+              </span>
+            </span>
+          ))}
+        </div>
+        <input 
+          className="flex-grow bg-gray-100 rounded-md p-2 focus:outline-none focus:ring-2 focus:ring-purple-500" 
+          placeholder="" 
+          type="text"
+          value={searchValue}
+          onChange={(e) => onSearchChange(e.target.value)}
+        />
+        <span className="material-icons absolute right-5 text-gray-400">search</span>
+      </div>
+
+      {/* 通常の検索ボックス */}
+      <div className="relative bg-white p-3 rounded-lg shadow-sm border border-gray-200 flex items-center">
+        <input 
+          className="flex-grow bg-gray-100 rounded-md p-2 focus:outline-none focus:ring-2 focus:ring-purple-500" 
+          placeholder={placeholder} 
+          type="text"
+          value={searchValue}
+          onChange={(e) => onSearchChange(e.target.value)}
+        />
+        <span className="material-icons absolute right-5 text-gray-400">search</span>
+      </div>
+    </div>
+  );
+}

--- a/src/app/articles/page.tsx
+++ b/src/app/articles/page.tsx
@@ -1,13 +1,116 @@
 
-export default function ArticlesPage() {
-  
+'use client';
 
+import { useState } from 'react';
+import Header from './components/Header';
+import SearchAndFilter from './components/SearchAndFilter';
+import ArticleCard from './components/ArticleCard';
+import Pagination from './components/Pagination';
+
+interface Tag {
+  id: string;
+  name: string;
+  color: string;
+}
+
+interface Article {
+  id: string;
+  title: string;
+  description: string;
+  icon?: string;
+}
+
+// サンプルデータ
+const sampleTags: Tag[] = [
+  { id: '1', name: 'Next', color: 'bg-blue-500' },
+  { id: '2', name: 'React', color: 'bg-teal-500' },
+];
+
+const sampleArticles: Article[] = [
+  {
+    id: '1',
+    title: '記事のタイトル',
+    description: 'ここに記事の短い説明が入ります。読者の興味を引くような内容を記述します。',
+  },
+  {
+    id: '2',
+    title: '記事のタイトル',
+    description: 'ここに記事の短い説明が入ります。読者の興味を引くような内容を記述します。',
+  },
+  {
+    id: '3',
+    title: '記事のタイトル',
+    description: 'ここに記事の短い説明が入ります。読者の興味を引くような内容を記述します。',
+  },
+  {
+    id: '4',
+    title: '記事のタイトル',
+    description: 'ここに記事の短い説明が入ります。読者の興味を引くような内容を記述します。',
+  },
+  {
+    id: '5',
+    title: '記事のタイトル',
+    description: 'ここに記事の短い説明が入ります。読者の興味を引くような内容を記述します。',
+  },
+  {
+    id: '6',
+    title: '記事のタイトル',
+    description: 'ここに記事の短い説明が入ります。読者の興味を引くような内容を記述します。',
+  },
+];
+
+export default function ArticlesPage() {
+  const [selectedTags, setSelectedTags] = useState<Tag[]>(sampleTags);
+  const [searchValue, setSearchValue] = useState('');
+  const [currentPage, setCurrentPage] = useState(1);
+  
+  const totalPages = 68; // サンプルデータ
+
+  const handleTagRemove = (tagId: string) => {
+    setSelectedTags(prev => prev.filter(tag => tag.id !== tagId));
+  };
+
+  const handleSearchChange = (value: string) => {
+    setSearchValue(value);
+  };
+
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page);
+  };
+
+  const handleArticleClick = (articleId: string) => {
+    // 記事詳細ページへの遷移処理
+    console.log('Article clicked:', articleId);
+  };
 
   return (
-    
-    <div>
-      <h1>Articles</h1>
+    <div className="bg-gray-50 text-gray-800 min-h-screen">
+      <div className="container mx-auto px-4 py-8">
+        <Header />
+        
+        <SearchAndFilter
+          selectedTags={selectedTags}
+          onTagRemove={handleTagRemove}
+          searchValue={searchValue}
+          onSearchChange={handleSearchChange}
+        />
+
+        <main className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8 mb-10">
+          {sampleArticles.map((article) => (
+            <ArticleCard
+              key={article.id}
+              article={article}
+              onClick={() => handleArticleClick(article.id)}
+            />
+          ))}
+        </main>
+
+        <Pagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+          onPageChange={handlePageChange}
+        />
+      </div>
     </div>
-    
   );
 }


### PR DESCRIPTION
Implement the article list screen (`ArticlesPage`) based on `docs/design/all_view.html`, using Tailwind CSS and componentization to faithfully reproduce the design.

---
<a href="https://cursor.com/background-agent?bcId=bc-6803090a-21ec-4b41-a4ff-c56025d66fad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6803090a-21ec-4b41-a4ff-c56025d66fad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

