### PR TITLE
Create articles list page with tailwind css

### DIFF
--- a/src/app/articles/page.tsx
+++ b/src/app/articles/page.tsx
@@ -1,11 +1,115 @@
 'use client';
 
+import { useState } from 'react';
+import ArticleCard from '@/components/ArticleCard';
+import SearchSection from '@/components/SearchSection';
+import Pagination from '@/components/Pagination';
 
+// 記事データの型定義
+interface Article {
+  id: number;
+  title: string;
+  description: string;
+  icon?: string;
+}
+
+// タグの型定義
+interface Tag {
+  id: number;
+  name: string;
+  color: string;
+}
 
 export default function ArticlesPage() {
+  const [selectedTags, setSelectedTags] = useState<Tag[]>([
+    { id: 1, name: 'Next', color: 'bg-blue-500' },
+    { id: 2, name: 'React', color: 'bg-teal-500' }
+  ]);
+  const [searchText, setSearchText] = useState('');
+  const [hintSearchText, setHintSearchText] = useState('');
+
+  // サンプル記事データ
+  const articles: Article[] = [
+    {
+      id: 1,
+      title: '記事のタイトル',
+      description: 'ここに記事の短い説明が入ります。読者の興味を引くような内容を記述します。'
+    },
+    {
+      id: 2,
+      title: '記事のタイトル',
+      description: 'ここに記事の短い説明が入ります。読者の興味を引くような内容を記述します。'
+    },
+    {
+      id: 3,
+      title: '記事のタイトル',
+      description: 'ここに記事の短い説明が入ります。読者の興味を引くような内容を記述します。'
+    },
+    {
+      id: 4,
+      title: '記事のタイトル',
+      description: 'ここに記事の短い説明が入ります。読者の興味を引くような内容を記述します。'
+    },
+    {
+      id: 5,
+      title: '記事のタイトル',
+      description: 'ここに記事の短い説明が入ります。読者の興味を引くような内容を記述します。'
+    },
+    {
+      id: 6,
+      title: '記事のタイトル',
+      description: 'ここに記事の短い説明が入ります。読者の興味を引くような内容を記述します。'
+    }
+  ];
+
+  // タグを削除する関数
+  const removeTag = (tagId: number) => {
+    setSelectedTags(prev => prev.filter(tag => tag.id !== tagId));
+  };
 
   return (
-    <div>
+    <div className="bg-gray-50 text-gray-800 min-h-screen">
+      <div className="container mx-auto px-4 py-8">
+        {/* ヘッダー */}
+        <header className="flex justify-between items-center mb-10">
+          <h1 className="text-3xl font-bold text-purple-700">技術記事</h1>
+          <div className="w-12 h-12 bg-purple-600 rounded-full flex items-center justify-center">
+            <svg className="w-8 h-8 text-white" fill="currentColor" viewBox="0 0 24 24">
+              <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"/>
+            </svg>
+          </div>
+        </header>
+
+        {/* 検索エリア */}
+        <SearchSection
+          selectedTags={selectedTags}
+          onRemoveTag={removeTag}
+          searchText={searchText}
+          onSearchTextChange={setSearchText}
+          hintSearchText={hintSearchText}
+          onHintSearchTextChange={setHintSearchText}
+        />
+
+        {/* 記事カードグリッド */}
+        <main className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8 mb-10">
+          {articles.map(article => (
+            <ArticleCard
+              key={article.id}
+              id={article.id}
+              title={article.title}
+              description={article.description}
+              icon={article.icon}
+            />
+          ))}
+        </main>
+
+        {/* ページネーション */}
+        <Pagination 
+          currentPage={1}
+          totalPages={68}
+          onPageChange={(page) => console.log('Page changed to:', page)}
+        />
+      </div>
     </div>
   );
 }

--- a/src/components/ArticleCard.tsx
+++ b/src/components/ArticleCard.tsx
@@ -1,0 +1,22 @@
+interface ArticleCardProps {
+  id: number;
+  title: string;
+  description: string;
+  icon?: string;
+}
+
+export default function ArticleCard({ id, title, description, icon }: ArticleCardProps) {
+  return (
+    <div className="bg-white rounded-lg shadow-md overflow-hidden hover:shadow-xl transition-shadow duration-300">
+      <div className="bg-gray-200 h-48 flex items-center justify-center">
+        <div className="w-24 h-24 bg-blue-400 rounded-full flex items-center justify-center">
+          <span className="text-white text-sm">アイコン</span>
+        </div>
+      </div>
+      <div className="p-6">
+        <h2 className="text-xl font-semibold text-gray-800 mb-2">{title}</h2>
+        <p className="text-gray-600 text-sm">{description}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,0 +1,72 @@
+interface PaginationProps {
+  currentPage?: number;
+  totalPages?: number;
+  onPageChange?: (page: number) => void;
+}
+
+export default function Pagination({ 
+  currentPage = 1, 
+  totalPages = 68, 
+  onPageChange 
+}: PaginationProps) {
+  return (
+    <nav className="flex justify-center items-center space-x-2">
+      <a 
+        className="flex items-center px-3 py-2 text-gray-600 hover:text-purple-600 rounded-md cursor-pointer" 
+        onClick={() => onPageChange && onPageChange(Math.max(1, currentPage - 1))}
+      >
+        <svg className="w-4 h-4 mr-1" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M15.41 16.59L10.83 12l4.58-4.59L14 6l-6 6 6 6 1.41-1.41z"/>
+        </svg>
+        Previous
+      </a>
+      
+      <a 
+        className="px-4 py-2 bg-purple-600 text-white font-semibold rounded-md cursor-pointer"
+        onClick={() => onPageChange && onPageChange(1)}
+      >
+        1
+      </a>
+      
+      <a 
+        className="px-4 py-2 text-gray-600 hover:bg-gray-200 hover:text-purple-600 rounded-md cursor-pointer"
+        onClick={() => onPageChange && onPageChange(2)}
+      >
+        2
+      </a>
+      
+      <a 
+        className="px-4 py-2 text-gray-600 hover:bg-gray-200 hover:text-purple-600 rounded-md cursor-pointer"
+        onClick={() => onPageChange && onPageChange(3)}
+      >
+        3
+      </a>
+      
+      <span className="text-gray-600">...</span>
+      
+      <a 
+        className="px-4 py-2 text-gray-600 hover:bg-gray-200 hover:text-purple-600 rounded-md cursor-pointer"
+        onClick={() => onPageChange && onPageChange(67)}
+      >
+        67
+      </a>
+      
+      <a 
+        className="px-4 py-2 text-gray-600 hover:bg-gray-200 hover:text-purple-600 rounded-md cursor-pointer"
+        onClick={() => onPageChange && onPageChange(68)}
+      >
+        68
+      </a>
+      
+      <a 
+        className="flex items-center px-3 py-2 text-gray-600 hover:text-purple-600 rounded-md cursor-pointer"
+        onClick={() => onPageChange && onPageChange(Math.min(totalPages, currentPage + 1))}
+      >
+        Next
+        <svg className="w-4 h-4 ml-1" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M8.59 16.59L13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.41z"/>
+        </svg>
+      </a>
+    </nav>
+  );
+}

--- a/src/components/SearchSection.tsx
+++ b/src/components/SearchSection.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useState } from 'react';
+
+// タグの型定義
+interface Tag {
+  id: number;
+  name: string;
+  color: string;
+}
+
+interface SearchSectionProps {
+  selectedTags: Tag[];
+  onRemoveTag: (tagId: number) => void;
+  searchText: string;
+  onSearchTextChange: (text: string) => void;
+  hintSearchText: string;
+  onHintSearchTextChange: (text: string) => void;
+}
+
+export default function SearchSection({
+  selectedTags,
+  onRemoveTag,
+  searchText,
+  onSearchTextChange,
+  hintSearchText,
+  onHintSearchTextChange
+}: SearchSectionProps) {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-10">
+      {/* タグフィルター付き検索ボックス */}
+      <div className="relative bg-white p-3 rounded-lg shadow-sm border border-gray-200 flex items-center">
+        <div className="flex items-center flex-wrap gap-2 mr-3">
+          {selectedTags.map(tag => (
+            <span key={tag.id} className={`${tag.color} text-white px-3 py-1 rounded-full text-sm font-medium flex items-center`}>
+              {tag.name}
+              <button 
+                onClick={() => onRemoveTag(tag.id)}
+                className="ml-1 hover:bg-black hover:bg-opacity-20 rounded-full p-1"
+              >
+                <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 24 24">
+                  <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
+                </svg>
+              </button>
+            </span>
+          ))}
+        </div>
+        <input 
+          className="flex-grow bg-gray-100 rounded-md p-2 focus:outline-none focus:ring-2 focus:ring-purple-500" 
+          placeholder="" 
+          type="text"
+          value={searchText}
+          onChange={(e) => onSearchTextChange(e.target.value)}
+        />
+        <svg className="absolute right-5 w-5 h-5 text-gray-400" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/>
+        </svg>
+      </div>
+
+      {/* ヒント付き検索ボックス */}
+      <div className="relative bg-white p-3 rounded-lg shadow-sm border border-gray-200 flex items-center">
+        <input 
+          className="flex-grow bg-gray-100 rounded-md p-2 focus:outline-none focus:ring-2 focus:ring-purple-500" 
+          placeholder="Hinted search text" 
+          type="text"
+          value={hintSearchText}
+          onChange={(e) => onHintSearchTextChange(e.target.value)}
+        />
+        <svg className="absolute right-5 w-5 h-5 text-gray-400" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/>
+        </svg>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Add the article list page (`ArticlesPage`) and its components, faithfully replicating the `docs/design/all_view.html` design using Tailwind CSS.

---
<a href="https://cursor.com/background-agent?bcId=bc-d6b073c4-5b58-44fd-bc06-593562a67996">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d6b073c4-5b58-44fd-bc06-593562a67996">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

